### PR TITLE
Fix hardcoded eth0

### DIFF
--- a/lora_pkt_fwd/update_gwid.sh
+++ b/lora_pkt_fwd/update_gwid.sh
@@ -16,7 +16,7 @@ get_ether() {
     local iface
     iface="$1"
     ip link show ${iface} | sed -nE \
-        's,^.*ether ([^[:space:]]+)[[:space:]].*$,\1,p'
+        's,^.*ether ([^[:space:]]+)[[:space:]].*$,\1,p'|tr '[a-z]' '[A-Z]'
 }
 
 get_ether_first3() {
@@ -61,7 +61,7 @@ iot_sk_update_gwid() {
     # replace last 8 digits of default gateway ID by actual GWID, in given
     # JSON configuration file
     sed -i.bak -E \
-        "s/(^[[:space:]]*\"gateway_ID\":[[:space:]]*\").{16}\"[[:space:]]*(,?).*$/\1${gwid}\2/" ${conf}
+        "s/(^[[:space:]]*\"gateway_ID\":[[:space:]]*\").{16}\"[[:space:]]*(,?).*$/\1${gwid}\"\2/" ${conf}
 
     echo "Gateway_ID set to ${gwid} in file ${conf}"
     echo "   To roll back: mv ${conf}.bak ${conf}"

--- a/lora_pkt_fwd/update_gwid.sh
+++ b/lora_pkt_fwd/update_gwid.sh
@@ -7,25 +7,75 @@
 # Usage examples:
 #       ./update_gwid.sh ./local_conf.json
 
+_ether=""
+get_default_interface() {
+    netstat -rn | sed -nE '/^0.0.0.0/ s,^.* ([a-z]+[0-9])$,\1,p'
+}
+
+get_ether() {
+    local iface
+    iface="$1"
+    ip link show ${iface} | sed -nE \
+        's,^.*ether ([^[:space:]]+)[[:space:]].*$,\1,p'
+}
+
+get_ether_first3() {
+    echo ${_ether}|cut -c 1-2,4-5,7-8
+}
+
+get_ether_last3() {
+    echo ${_ether}|cut -c 10-11,13-14,16-17
+}
+
 iot_sk_update_gwid() {
-    # get gateway ID from its MAC address to generate an EUI-64 address
-    GWID_MIDFIX="FFFE"
-    GWID_BEGIN=$(ip link show eth0 | awk '/ether/ {print $2}' | awk -F\: '{print $1$2$3}')
-    GWID_END=$(ip link show eth0 | awk '/ether/ {print $2}' | awk -F\: '{print $4$5$6}')
+    local iface conf _begin _end gwid
+    iface=$(get_default_interface)
+    conf="$1"
+    if [ -z "${iface}" ]
+    then
+        echo "No IPv4 gateway configured. IPv6 currently unsupported." >&2
+        return 78 # EX_CONFIG
+    fi
+    _ether=$(get_ether ${iface})
+    if [ -z "${_ether}" ]
+    then
+        echo "Default interface does not have a MAC address." >&2
+        return 78 # EX_CONFIG
+    fi
+    if [ ! -f ${conf} ]
+    then
+        echo "File ${conf} does not exist" >&2
+        return 66 # EX_NOINPUT
+    fi
+    if [ ! -w ${conf} ]
+    then
+        echo "File ${conf} is not writeable by us" >&2
+        return 73 # EX_CANTCREAT
+    fi
 
-    # replace last 8 digits of default gateway ID by actual GWID, in given JSON configuration file
-    sed -i 's/\(^\s*"gateway_ID":\s*"\).\{16\}"\s*\(,\?\).*$/\1'${GWID_BEGIN}${GWID_MIDFIX}${GWID_END}'"\2/' $1
+    _begin=$(get_ether_first3)
+    _end=$(get_ether_last3)
+    gwid="${_begin}FFFE${_end}"
 
-    echo "Gateway_ID set to "$GWID_BEGIN$GWID_MIDFIX$GWID_END" in file "$1
+
+    # replace last 8 digits of default gateway ID by actual GWID, in given
+    # JSON configuration file
+    sed -i.bak -E \
+        "s/(^[[:space:]]*\"gateway_ID\":[[:space:]]*\").{16}\"[[:space:]]*(,?).*$/\1${gwid}\2/" ${conf}
+
+    echo "Gateway_ID set to ${gwid} in file ${conf}"
+    echo "   To roll back: mv ${conf}.bak ${conf}"
+    echo "   When satisfied: rm ${conf}.bak"
+    return 0 # EX_OK
 }
 
 if [ $# -ne 1 ]
 then
-    echo "Usage: $0 [filename]"
-    echo "  filename: Path to JSON file containing Gateway_ID for packet forwarder"
-    exit 1
+    echo "Usage: $0 <filename>" >&2
+    echo "  filename: Path to JSON file containing Gateway_ID for packet forwarder" >&2
+    exit 64 # EX_USAGE
 fi 
 
 iot_sk_update_gwid $1
 
-exit 0
+exit $?


### PR DESCRIPTION
The current script is rather fragile, not very verbose and hardcodes eth0 to be the interface we get the ethernet ID from.

While this would work with most embedded boards running linux, it still doesn't mean eth0 is actually in use (in our case it's wlan0 that is).

Also try to be as compatible as possible and avoid awk when we can.