### PR TITLE
Add TX LUT entries for USA configurations

### DIFF
--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.basic
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.basic
@@ -82,6 +82,90 @@
             "if": 300000,
             "bandwidth": 250000,
             "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 9,
+            "rf_power": 20,
+            "dig_gain": 0
         }
     },
 

--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.beacon
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.beacon
@@ -1,0 +1,203 @@
+{
+    "SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 902700000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_freq_min": 902000000,
+            "tx_freq_max": 928000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 903400000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 902.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 902.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 902.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 902.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 903.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -300000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 903.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -100000
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 903.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 100000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 903.7 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 500kHz, SF8, 903.0 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 500000,
+            "spread_factor": 8
+        },
+        "chan_FSK": {
+            /* FSK 100kbps channel, 903.0 MHz */
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 9,
+            "rf_power": 20,
+            "dig_gain": 0
+        }
+    },
+
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "localhost",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false,
+        /* GPS configuration */
+        "gps_tty_path": "/dev/ttyAMA0",
+        /* GPS reference coordinates */
+        "ref_latitude": 0.0,
+        "ref_longitude": 0.0,
+        "ref_altitude": 0,
+        /* Beaconing parameters */
+        "beacon_period": 128,
+        "beacon_freq_hz": 923300000,
+        "beacon_freq_nb": 8,
+        "beacon_freq_step": 600000,
+        "beacon_datarate": 12,
+        "beacon_bw_hz": 500000,
+        "beacon_power": 14,
+        "beacon_infodesc": 0
+    }
+}
+

--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.gps
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E286.US902.gps
@@ -1,0 +1,194 @@
+{
+    "SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 902700000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_freq_min": 902000000,
+            "tx_freq_max": 928000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 903400000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 902.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 902.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 902.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 902.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 903.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -300000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 903.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -100000
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 903.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 100000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 903.7 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 500kHz, SF8, 903.0 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 500000,
+            "spread_factor": 8
+        },
+        "chan_FSK": {
+            /* FSK 100kbps channel, 903.0 MHz */
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 0
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 0
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 12,
+            "rf_power": 0,
+            "dig_gain": 0
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 1,
+            "mix_gain": 8,
+            "rf_power": 3,
+            "dig_gain": 0
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 0
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 0
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 11,
+            "dig_gain": 0
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 15,
+            "rf_power": 13,
+            "dig_gain": 0
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 2,
+            "mix_gain": 10,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 16,
+            "dig_gain": 0
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 3,
+            "mix_gain": 9,
+            "rf_power": 20,
+            "dig_gain": 0
+        }
+    },
+
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "localhost",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false,
+        /* GPS configuration */
+        "gps_tty_path": "/dev/ttyAMA0",
+        /* GPS reference coordinates */
+        "ref_latitude": 0.0,
+        "ref_longitude": 0.0,
+        "ref_altitude": 0
+    }
+}
+

--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.basic
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.basic
@@ -1,0 +1,216 @@
+{
+    "SX1301_conf": {
+        "lorawan_public": true,
+        "clksrc": 1, /* radio_1 provides clock to concentrator */
+        "antenna_gain": 0, /* antenna gain, in dBi */
+        "radio_0": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 902700000,
+            "rssi_offset": -166.0,
+            "tx_enable": true,
+            "tx_freq_min": 902000000,
+            "tx_freq_max": 928000000
+        },
+        "radio_1": {
+            "enable": true,
+            "type": "SX1257",
+            "freq": 903400000,
+            "rssi_offset": -166.0,
+            "tx_enable": false
+        },
+        "chan_multiSF_0": {
+            /* Lora MAC channel, 125kHz, all SF, 902.3 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -400000
+        },
+        "chan_multiSF_1": {
+            /* Lora MAC channel, 125kHz, all SF, 902.5 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": -200000
+        },
+        "chan_multiSF_2": {
+            /* Lora MAC channel, 125kHz, all SF, 902.7 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 0
+        },
+        "chan_multiSF_3": {
+            /* Lora MAC channel, 125kHz, all SF, 902.9 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 200000
+        },
+        "chan_multiSF_4": {
+            /* Lora MAC channel, 125kHz, all SF, 903.1 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -300000
+        },
+        "chan_multiSF_5": {
+            /* Lora MAC channel, 125kHz, all SF, 903.3 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": -100000
+        },
+        "chan_multiSF_6": {
+            /* Lora MAC channel, 125kHz, all SF, 903.5 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 100000
+        },
+        "chan_multiSF_7": {
+            /* Lora MAC channel, 125kHz, all SF, 903.7 MHz */
+            "enable": true,
+            "radio": 1,
+            "if": 300000
+        },
+        "chan_Lora_std": {
+            /* Lora MAC channel, 500kHz, SF8, 903.0 MHz */
+            "enable": true,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 500000,
+            "spread_factor": 8
+        },
+        "chan_FSK": {
+            /* FSK 100kbps channel, 903.0 MHz */
+            "enable": false,
+            "radio": 0,
+            "if": 300000,
+            "bandwidth": 250000,
+            "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 3
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 3
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": 0,
+            "dig_gain": 1
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 0,
+            "mix_gain": 14,
+            "rf_power": 3,
+            "dig_gain": 2
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 3
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 2
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 11,
+            "dig_gain": 1
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 14,
+            "rf_power": 13,
+            "dig_gain": 2
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 16,
+            "dig_gain": 2
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 20,
+            "dig_gain": 1
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 2,
+            "mix_gain": 13,
+            "rf_power": 23,
+            "dig_gain": 1
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 2,
+            "mix_gain": 15,
+            "rf_power": 25,
+            "dig_gain": 2
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 26,
+            "dig_gain": 2
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 27,
+            "dig_gain": 1
+        }
+    },
+
+    "gateway_conf": {
+        "gateway_ID": "AA555A0000000000",
+        /* change with default server address/ports, or overwrite in local_conf.json */
+        "server_address": "localhost",
+        "serv_port_up": 1680,
+        "serv_port_down": 1680,
+        /* adjust the following parameters for your network */
+        "keepalive_interval": 10,
+        "stat_interval": 30,
+        "push_timeout_ms": 100,
+        /* forward only valid packets */
+        "forward_crc_valid": true,
+        "forward_crc_error": false,
+        "forward_crc_disabled": false
+    }
+}
+

--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.beacon
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.beacon
@@ -82,6 +82,118 @@
             "if": 300000,
             "bandwidth": 250000,
             "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 3
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 3
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": 0,
+            "dig_gain": 1
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 0,
+            "mix_gain": 14,
+            "rf_power": 3,
+            "dig_gain": 2
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 3
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 2
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 11,
+            "dig_gain": 1
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 14,
+            "rf_power": 13,
+            "dig_gain": 2
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 16,
+            "dig_gain": 2
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 20,
+            "dig_gain": 1
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 2,
+            "mix_gain": 13,
+            "rf_power": 23,
+            "dig_gain": 1
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 2,
+            "mix_gain": 15,
+            "rf_power": 25,
+            "dig_gain": 2
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 26,
+            "dig_gain": 2
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 27,
+            "dig_gain": 1
         }
     },
 
@@ -104,7 +216,16 @@
         /* GPS reference coordinates */
         "ref_latitude": 0.0,
         "ref_longitude": 0.0,
-        "ref_altitude": 0
+        "ref_altitude": 0,
+        /* Beaconing parameters */
+        "beacon_period": 128,
+        "beacon_freq_hz": 923300000,
+        "beacon_freq_nb": 8,
+        "beacon_freq_step": 600000,
+        "beacon_datarate": 12,
+        "beacon_bw_hz": 500000,
+        "beacon_power": 14,
+        "beacon_infodesc": 0
     }
 }
 

--- a/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.gps
+++ b/lora_pkt_fwd/cfg/global_conf.json.PCB_E336.US902.gps
@@ -82,6 +82,118 @@
             "if": 300000,
             "bandwidth": 250000,
             "datarate": 100000
+        },
+        "tx_lut_0": {
+            /* TX gain table, index 0 */
+            "pa_gain": 0,
+            "mix_gain": 8,
+            "rf_power": -6,
+            "dig_gain": 3
+        },
+        "tx_lut_1": {
+            /* TX gain table, index 1 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": -3,
+            "dig_gain": 3
+        },
+        "tx_lut_2": {
+            /* TX gain table, index 2 */
+            "pa_gain": 0,
+            "mix_gain": 10,
+            "rf_power": 0,
+            "dig_gain": 1
+        },
+        "tx_lut_3": {
+            /* TX gain table, index 3 */
+            "pa_gain": 0,
+            "mix_gain": 14,
+            "rf_power": 3,
+            "dig_gain": 2
+        },
+        "tx_lut_4": {
+            /* TX gain table, index 4 */
+            "pa_gain": 1,
+            "mix_gain": 10,
+            "rf_power": 6,
+            "dig_gain": 3
+        },
+        "tx_lut_5": {
+            /* TX gain table, index 5 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 10,
+            "dig_gain": 2
+        },
+        "tx_lut_6": {
+            /* TX gain table, index 6 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 11,
+            "dig_gain": 1
+        },
+        "tx_lut_7": {
+            /* TX gain table, index 7 */
+            "pa_gain": 1,
+            "mix_gain": 12,
+            "rf_power": 12,
+            "dig_gain": 0
+        },
+        "tx_lut_8": {
+            /* TX gain table, index 8 */
+            "pa_gain": 1,
+            "mix_gain": 14,
+            "rf_power": 13,
+            "dig_gain": 2
+        },
+        "tx_lut_9": {
+            /* TX gain table, index 9 */
+            "pa_gain": 1,
+            "mix_gain": 13,
+            "rf_power": 14,
+            "dig_gain": 0
+        },
+        "tx_lut_10": {
+            /* TX gain table, index 10 */
+            "pa_gain": 2,
+            "mix_gain": 9,
+            "rf_power": 16,
+            "dig_gain": 2
+        },
+        "tx_lut_11": {
+            /* TX gain table, index 11 */
+            "pa_gain": 2,
+            "mix_gain": 11,
+            "rf_power": 20,
+            "dig_gain": 1
+        },
+        "tx_lut_12": {
+            /* TX gain table, index 12 */
+            "pa_gain": 2,
+            "mix_gain": 13,
+            "rf_power": 23,
+            "dig_gain": 1
+        },
+        "tx_lut_13": {
+            /* TX gain table, index 13 */
+            "pa_gain": 2,
+            "mix_gain": 15,
+            "rf_power": 25,
+            "dig_gain": 2
+        },
+        "tx_lut_14": {
+            /* TX gain table, index 14 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 26,
+            "dig_gain": 2
+        },
+        "tx_lut_15": {
+            /* TX gain table, index 15 */
+            "pa_gain": 3,
+            "mix_gain": 10,
+            "rf_power": 27,
+            "dig_gain": 1
         }
     },
 
@@ -104,16 +216,7 @@
         /* GPS reference coordinates */
         "ref_latitude": 0.0,
         "ref_longitude": 0.0,
-        "ref_altitude": 0,
-        /* Beaconing parameters */
-        "beacon_period": 128,
-        "beacon_freq_hz": 923300000,
-        "beacon_freq_nb": 8,
-        "beacon_freq_step": 600000,
-        "beacon_datarate": 12,
-        "beacon_bw_hz": 500000,
-        "beacon_power": 14,
-        "beacon_infodesc": 0
+        "ref_altitude": 0
     }
 }
 


### PR DESCRIPTION
This is a first step to improve the USA configurations. As the LUT entries are dependent on the reference hardware, and specral mask and emissions are global standards, these should be the same values as for EU. I've split the configurations into two sets of files in line with how the values differ for the 286 and 336 gateways in the current EU configurations. If this is correct, then it should close https://github.com/Lora-net/packet_forwarder/issues/83