### PR TITLE
Independent build

### DIFF
--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -1,0 +1,52 @@
+name: Compile Docker Images
+
+on: [push]
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            nebraltd/lora_gateway
+            ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=true
+          tags: |
+            type=sha,prefix=
+            type=sha,format=long,prefix=
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Builds lora_pkt_fwd for each SPI bus and copies each to
+# $OUTPUT_DIR/ respectively.
+
+FROM balenalib/raspberry-pi-debian:buster-build as sx1301-builder
+
+ENV ROOT_DIR=/opt
+ENV LORA_GATEWAY_OUTPUT_DIR=/opt/output
+ENV LORA_GATEWAY_INPUT_DIR="$ROOT_DIR/lora_gateway_builds"
+ENV PACKET_FORWARDER_INPUT_DIR="$ROOT_DIR/packet_forwarder"
+
+ENV OUTPUT_DIR="$ROOT_DIR/output"
+
+WORKDIR "$ROOT_DIR"
+
+# Copy upstream source into expected location
+COPY . "$PACKET_FORWARDER_INPUT_DIR"
+COPY --from=marvinnebra/lora_gateway "$LORA_GATEWAY_OUTPUT_DIR" "$LORA_GATEWAY_INPUT_DIR"
+
+RUN . "$PACKET_FORWARDER_INPUT_DIR/compile_lora_pkt_fwd.sh"

--- a/compile_lora_pkt_fwd.sh
+++ b/compile_lora_pkt_fwd.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+compile_lora_pkt_fwd_for_spi_bus() {
+    spi_bus="$1"
+    echo "Compiling upstream lora_pkt_fwd for sx1301 on $spi_bus"
+
+    # lora_pkt_fwd Makefile expects lora_gateway to be to levels up
+    rm -rf "$ROOT_DIR/lora_gateway"
+    mkdir -p "$ROOT_DIR/lora_gateway"
+    cp -r "$LORA_GATEWAY_INPUT_DIR/$spi_bus/" "$ROOT_DIR/lora_gateway/libloragw/"
+
+    cd "$PACKET_FORWARDER_INPUT_DIR/lora_pkt_fwd" || exit
+    make clean
+    make -j 4
+
+    cp -R "$LORA_GATEWAY_INPUT_DIR/lora_pkt_fwd/lora_pkt_fwd" "$OUTPUT_DIR/lora_pkt_fwd_$spi_bus"
+
+    echo "Finished building lora_pkt_fwd for sx1301 on $spi_bus in $OUTPUT_DIR"
+}
+
+compile_lora_pkt_fwd() {
+    echo "Compiling libloragw for sx1301 concentrator on all the necessary SPI buses in $ROOT_DIR"
+    
+    # Built outputs will be copied to this directory
+    mkdir -p "$OUTPUT_DIR"
+    
+    # In order to be more portable, intentionally not interating over an array
+    compile_lora_pkt_fwd_for_spi_bus spidev0.0
+    compile_lora_pkt_fwd_for_spi_bus spidev0.1
+    compile_lora_pkt_fwd_for_spi_bus spidev1.0
+    compile_lora_pkt_fwd_for_spi_bus spidev1.1
+    compile_lora_pkt_fwd_for_spi_bus spidev1.2
+    compile_lora_pkt_fwd_for_spi_bus spidev2.0
+    compile_lora_pkt_fwd_for_spi_bus spidev2.1
+    compile_lora_pkt_fwd_for_spi_bus spidev32766.0
+}
+
+compile_lora_pkt_fwd
+

--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
+++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
@@ -980,8 +980,8 @@ int main(void)
     int x;
 
     /* configuration file related */
-    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder_sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
-    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder_sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
+    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder/sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
+    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder/sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
     char *debug_cfg_path = "debug_conf.json"; /* if present, all other configuration files are ignored */
 
     /* threads */

--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
+++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
@@ -980,8 +980,8 @@ int main(void)
     int x;
 
     /* configuration file related */
-    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder_sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
-    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder_sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
+    char *global_cfg_path= "global_conf.json"; /* contain global (typ. network-wide) configuration */
+    char *local_cfg_path = "local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
     char *debug_cfg_path = "debug_conf.json"; /* if present, all other configuration files are ignored */
 
     /* threads */

--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
+++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
@@ -980,8 +980,8 @@ int main(void)
     int x;
 
     /* configuration file related */
-    char *global_cfg_path= "global_conf.json"; /* contain global (typ. network-wide) configuration */
-    char *local_cfg_path = "local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
+    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder_sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
+    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder_sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
     char *debug_cfg_path = "debug_conf.json"; /* if present, all other configuration files are ignored */
 
     /* threads */

--- a/lora_pkt_fwd/src/lora_pkt_fwd.c
+++ b/lora_pkt_fwd/src/lora_pkt_fwd.c
@@ -980,8 +980,8 @@ int main(void)
     int x;
 
     /* configuration file related */
-    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder/sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
-    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder/sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
+    char *global_cfg_path= "/opt/iotloragateway/packet_forwarder_sx1301/global_conf.json"; /* contain global (typ. network-wide) configuration */
+    char *local_cfg_path = "/opt/iotloragateway/packet_forwarder_sx1301/local_conf.json"; /* contain node specific configuration, overwrite global parameters for parameters that are defined in both */
     char *debug_cfg_path = "debug_conf.json"; /* if present, all other configuration files are ignored */
 
     /* threads */


### PR DESCRIPTION
**Why**
The hm-pktfwd build process is confusing. This is one of two proposals on how to structure the Dockerfile in order to improve things. 

**How**
This proposal builds each library and then references one from the other. This proposal is most correct in that it cleanly separates each build process. The downside is that it requires more cognitive load to connect the build stages together across different repos.

The other proposal builds everything all at once in hm-pktfwd.

**References**
- Part 1 of this proposal: https://github.com/Lora-net/lora_gateway/pull/172
- All-in-one proposal: https://github.com/NebraLtd/hm-pktfwd/pull/58